### PR TITLE
Add fromStrictResult

### DIFF
--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -65,6 +65,7 @@ module Data.ByteString.Streaming (
     , fromChunks       -- fromChunks :: Monad m => Stream (Of ByteString) m r -> ByteString m r 
     , toChunks         -- toChunks :: Monad m => ByteString m r -> Stream (Of ByteString) m r 
     , fromStrict       -- fromStrict :: ByteString -> ByteString m () 
+    , fromStrictResult -- fromStrictResult :: ByteString -> r -> ByteString m r
     , toStrict         -- toStrict :: Monad m => ByteString m () -> m ByteString 
     , toStrict_        -- toStrict_ :: Monad m => ByteString m r -> m (Of ByteString r) 
     , effects
@@ -311,9 +312,15 @@ toChunks bs =
 {-| /O(1)/ yield a strict 'ByteString' chunk. 
 -}
 fromStrict :: P.ByteString -> ByteString m ()
-fromStrict bs | S.null bs = Empty ()
-              | otherwise = Chunk bs  (Empty ())
+fromStrict bs = fromStrictResult bs ()
 {-# INLINE fromStrict #-}
+
+{-| /O(1) yeild a strict 'ByteString' chunk with a specified result.
+-}
+fromStrictResult :: P.ByteString -> r -> ByteString m r
+fromStrictResult bs r | S.null bs = Empty r
+                      | otherwise = Chunk bs (Empty r)
+{-# INLINE fromStrictResult #-}
 
 {-| /O(n)/ Convert a byte stream into a single strict 'ByteString'.
 

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -23,6 +23,7 @@ module Data.ByteString.Streaming.Char8 (
     , fromChunks       -- fromChunks :: Monad m => Stream (Of ByteString) m r -> ByteString m r 
     , fromLazy         -- fromLazy :: Monad m => ByteString -> ByteString m () 
     , fromStrict       -- fromStrict :: ByteString -> ByteString m () 
+    , fromStrictResult -- fromStrictResult :: ByteString -> r -> ByteString m r
     , toChunks         -- toChunks :: Monad m => ByteString m r -> Stream (Of ByteString) m r 
     , toLazy           -- toLazy :: Monad m => ByteString m () -> m ByteString 
     , toLazy_
@@ -177,7 +178,7 @@ import Data.ByteString.Streaming.Internal
 
 import Data.ByteString.Streaming
     (fromLazy, toLazy, toLazy_, nextChunk, unconsChunk, 
-    fromChunks, toChunks, fromStrict, toStrict, toStrict_, 
+    fromChunks, toChunks, fromStrict, fromStrictResult, toStrict, toStrict_, 
     concat, distribute, effects, drained, mwrap, toStreamingByteStringWith,
     toStreamingByteString, toBuilder, concatBuilders,
     empty, null, nulls, null_, testNull, length, length_, append, cycle, 


### PR DESCRIPTION
This will be especially useful after michaelt/streaming#28 is merged in, as that way if you have a `Stream (Of P.ByteString) m r` where each element is a separate line, then `unlines . maps (uncurry' fromStrictResult)` will give you the overall `ByteString m r` that it corresponds to.